### PR TITLE
Update: AWS_SECRET_ACCESS_KEY

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - backend
     environment:
       - AWS_ACCESS_KEY_ID=${MINIO_ACCESS_KEY}
-      - AWS_SECRET_ACCESS_KEY=${MINIO_ROOT_USER}
+      - AWS_SECRET_ACCESS_KEY=${MINIO_SECRET_ACCESS_KEY}
       - MLFLOW_S3_ENDPOINT_URL=http://s3:${MINIO_PORT_API}
     command: >
       mlflow server 


### PR DESCRIPTION
To listing model artifacts, you need update the docker-compose file, by:
Update AWS_SECRET_ACCESS_KEY=${MINIO_SECRET_ACCESS_KEY} in tracking_server to fix the api list model artifacts error, cause: 
```
botocore.exceptions.ClientError: An error occurred (SignatureDoesNotMatch) when calling the ListObjectsV2 operation: The request signature we calculated does not match the signature you provided. Check your key and signing method.
```
API list model artifacts error:
![image](https://github.com/pandego/mlflow-postgres-minio/assets/54660554/2ffbb417-96fc-40c9-9f33-5a2356f2b91b)

After update, it's working:
![image](https://github.com/pandego/mlflow-postgres-minio/assets/54660554/bc27844c-11ae-4a09-8025-fba8fc630890)

